### PR TITLE
docs(messaging-core): experimental banner + LICENSE check (QoL sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# workflow-plugin-messaging-core
+
+> ⚠️ **Experimental** — This plugin compiles and passes its unit tests but has not been validated in any active GoCodeAlone-internal production deployment. Use with caution. Please [open an issue](https://github.com/GoCodeAlone/workflow-plugin-messaging-core/issues/new) if you adopt it so we can promote it to **verified** status.
+
+Shared messaging interfaces and step contracts for workflow platform messaging plugins (Discord, Slack, Teams).
+
+## Install
+
+```sh
+wfctl plugin install workflow-plugin-messaging-core
+```
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- Add experimental status banner to README (newly created)
- LICENSE already MIT — no change needed

## Test plan

- [ ] README renders experimental banner correctly on GitHub

Cross-ref: workflow#714

🤖 Generated with [Claude Code](https://claude.com/claude-code)