### PR TITLE
feat: add ratchet notification bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Shared messaging interfaces and step contracts for workflow platform messaging p
 wfctl plugin install workflow-plugin-messaging-core
 ```
 
+## Ratchet notification handoff
+
+`ratchet blackboard export [section] --jsonl` emits local notification-event
+records with `messaging.text`. This package can parse those JSON or JSONL
+records with `ParseRatchetNotificationEvents` and project them into typed
+`step.messaging_send` input with `ProjectRatchetNotificationToMessagingSend`.
+
+Ratchet does not send Slack, Discord, Teams, webhook, or email messages
+directly. Downstream Workflow pipelines provide the target `channel` and use the
+platform plugins that own credentials, rate limits, redaction, retries, and
+delivery.
+
 ## License
 
 MIT

--- a/ratchet.go
+++ b/ratchet.go
@@ -101,8 +101,14 @@ func ParseRatchetNotificationEvents(r io.Reader) ([]RatchetNotificationEvent, er
 }
 
 func ProjectRatchetNotificationToMessagingSend(event RatchetNotificationEvent, channel string) (MessagingSendInput, error) {
+	channel = strings.TrimSpace(channel)
+	if channel == "" {
+		return MessagingSendInput{}, fmt.Errorf("messaging send channel is required")
+	}
 	text := strings.TrimSpace(event.Messaging.Text)
-	if event.Workflow != nil && event.Workflow.StepType == StepTypeMessagingSend {
+	if event.Workflow != nil &&
+		event.Workflow.StepType == StepTypeMessagingSend &&
+		event.Workflow.PluginFamily == PluginFamilyMessagingCore {
 		if workflowText := strings.TrimSpace(event.Workflow.Input.Text); workflowText != "" {
 			text = workflowText
 		}
@@ -111,7 +117,7 @@ func ProjectRatchetNotificationToMessagingSend(event RatchetNotificationEvent, c
 		return MessagingSendInput{}, fmt.Errorf("ratchet notification-event missing messaging.text")
 	}
 	return MessagingSendInput{
-		Channel: strings.TrimSpace(channel),
+		Channel: channel,
 		Text:    text,
 	}, nil
 }

--- a/ratchet.go
+++ b/ratchet.go
@@ -1,0 +1,117 @@
+package messaging
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	StepTypeMessagingSend        = "step.messaging_send"
+	PluginFamilyMessagingCore    = "workflow-plugin-messaging-core"
+	RatchetRequiredConfigChannel = "channel"
+)
+
+type MessagingSendInput struct {
+	Channel  string `json:"channel,omitempty"`
+	Text     string `json:"text"`
+	Provider string `json:"provider,omitempty"`
+}
+
+type RatchetNotificationEvent struct {
+	Section   string                     `json:"section"`
+	Key       string                     `json:"key"`
+	Value     string                     `json:"value,omitempty"`
+	Author    string                     `json:"author,omitempty"`
+	Revision  int64                      `json:"revision,omitempty"`
+	Timestamp string                     `json:"timestamp,omitempty"`
+	Messaging RatchetMessagingRecord     `json:"messaging"`
+	Workflow  *RatchetWorkflowProjection `json:"workflow,omitempty"`
+}
+
+type RatchetMessagingRecord struct {
+	Text string `json:"text"`
+}
+
+type RatchetWorkflowProjection struct {
+	StepType       string                    `json:"stepType"`
+	PluginFamily   string                    `json:"pluginFamily"`
+	Input          RatchetWorkflowInput      `json:"input"`
+	RequiredConfig []string                  `json:"requiredConfig,omitempty"`
+	Metadata       RatchetWorkflowSourceMeta `json:"metadata,omitempty"`
+}
+
+type RatchetWorkflowInput struct {
+	Text string `json:"text"`
+}
+
+type RatchetWorkflowSourceMeta struct {
+	Section string `json:"section,omitempty"`
+	Key     string `json:"key,omitempty"`
+}
+
+func ParseRatchetNotificationEvent(data []byte) (RatchetNotificationEvent, error) {
+	var event RatchetNotificationEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		return event, fmt.Errorf("parse ratchet notification-event: %w", err)
+	}
+	return event, nil
+}
+
+func ParseRatchetNotificationEvents(r io.Reader) ([]RatchetNotificationEvent, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read ratchet notification-events: %w", err)
+	}
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if data[0] == '[' {
+		var events []RatchetNotificationEvent
+		if err := json.Unmarshal(data, &events); err != nil {
+			return nil, fmt.Errorf("parse ratchet notification-event array: %w", err)
+		}
+		return events, nil
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	events := make([]RatchetNotificationEvent, 0)
+	line := 0
+	for scanner.Scan() {
+		line++
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" {
+			continue
+		}
+		event, err := ParseRatchetNotificationEvent([]byte(raw))
+		if err != nil {
+			return nil, fmt.Errorf("parse ratchet notification-event line %d: %w", line, err)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan ratchet notification-events: %w", err)
+	}
+	return events, nil
+}
+
+func ProjectRatchetNotificationToMessagingSend(event RatchetNotificationEvent, channel string) (MessagingSendInput, error) {
+	text := strings.TrimSpace(event.Messaging.Text)
+	if event.Workflow != nil && event.Workflow.StepType == StepTypeMessagingSend {
+		if workflowText := strings.TrimSpace(event.Workflow.Input.Text); workflowText != "" {
+			text = workflowText
+		}
+	}
+	if text == "" {
+		return MessagingSendInput{}, fmt.Errorf("ratchet notification-event missing messaging.text")
+	}
+	return MessagingSendInput{
+		Channel: strings.TrimSpace(channel),
+		Text:    text,
+	}, nil
+}

--- a/ratchet_test.go
+++ b/ratchet_test.go
@@ -1,0 +1,94 @@
+package messaging
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRatchetNotificationEventProjectsMessagingSend(t *testing.T) {
+	event, err := ParseRatchetNotificationEvent([]byte(`{
+		"section":"coordination",
+		"key":"status",
+		"value":"ready",
+		"author":"agent",
+		"revision":3,
+		"timestamp":"2026-07-05T06:00:00Z",
+		"messaging":{"text":"[coordination/status] ready"}
+	}`))
+	if err != nil {
+		t.Fatalf("parse event: %v", err)
+	}
+	if event.Section != "coordination" || event.Messaging.Text != "[coordination/status] ready" {
+		t.Fatalf("event = %#v", event)
+	}
+
+	input, err := ProjectRatchetNotificationToMessagingSend(event, "ops")
+	if err != nil {
+		t.Fatalf("project event: %v", err)
+	}
+	if input.Channel != "ops" || input.Text != "[coordination/status] ready" {
+		t.Fatalf("input = %#v", input)
+	}
+}
+
+func TestParseRatchetNotificationEventsJSONL(t *testing.T) {
+	events, err := ParseRatchetNotificationEvents(strings.NewReader(`
+{"section":"coordination","key":"status","messaging":{"text":"[coordination/status] ready"}}
+
+{"section":"release","key":"gate","messaging":{"text":"[release/gate] green"}}
+`))
+	if err != nil {
+		t.Fatalf("parse events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d", len(events))
+	}
+	if events[1].Messaging.Text != "[release/gate] green" {
+		t.Fatalf("events[1] = %#v", events[1])
+	}
+}
+
+func TestParseRatchetNotificationEventsJSONArray(t *testing.T) {
+	events, err := ParseRatchetNotificationEvents(strings.NewReader(`[
+		{"section":"coordination","key":"status","messaging":{"text":"[coordination/status] ready"}},
+		{"section":"release","key":"gate","messaging":{"text":"[release/gate] green"}}
+	]`))
+	if err != nil {
+		t.Fatalf("parse events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d", len(events))
+	}
+}
+
+func TestProjectRatchetNotificationUsesWorkflowProjection(t *testing.T) {
+	event, err := ParseRatchetNotificationEvent([]byte(`{
+		"section":"coordination",
+		"key":"handoff",
+		"messaging":{"text":"fallback"},
+		"workflow":{
+			"stepType":"step.messaging_send",
+			"pluginFamily":"workflow-plugin-messaging-core",
+			"input":{"text":"workflow text"},
+			"requiredConfig":["channel"],
+			"metadata":{"section":"coordination","key":"handoff"}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parse event: %v", err)
+	}
+	input, err := ProjectRatchetNotificationToMessagingSend(event, "triage")
+	if err != nil {
+		t.Fatalf("project event: %v", err)
+	}
+	if input.Text != "workflow text" || input.Channel != "triage" {
+		t.Fatalf("input = %#v", input)
+	}
+}
+
+func TestProjectRatchetNotificationRejectsMissingText(t *testing.T) {
+	_, err := ProjectRatchetNotificationToMessagingSend(RatchetNotificationEvent{}, "ops")
+	if err == nil {
+		t.Fatal("expected missing messaging text error")
+	}
+}

--- a/ratchet_test.go
+++ b/ratchet_test.go
@@ -86,6 +86,31 @@ func TestProjectRatchetNotificationUsesWorkflowProjection(t *testing.T) {
 	}
 }
 
+func TestProjectRatchetNotificationRejectsMissingChannel(t *testing.T) {
+	event := RatchetNotificationEvent{Messaging: RatchetMessagingRecord{Text: "ready"}}
+	if _, err := ProjectRatchetNotificationToMessagingSend(event, " "); err == nil {
+		t.Fatal("expected missing channel error")
+	}
+}
+
+func TestProjectRatchetNotificationIgnoresForeignWorkflowProjection(t *testing.T) {
+	event := RatchetNotificationEvent{
+		Messaging: RatchetMessagingRecord{Text: "fallback"},
+		Workflow: &RatchetWorkflowProjection{
+			StepType:     StepTypeMessagingSend,
+			PluginFamily: "other-plugin",
+			Input:        RatchetWorkflowInput{Text: "foreign text"},
+		},
+	}
+	input, err := ProjectRatchetNotificationToMessagingSend(event, "ops")
+	if err != nil {
+		t.Fatalf("project event: %v", err)
+	}
+	if input.Text != "fallback" {
+		t.Fatalf("input = %#v", input)
+	}
+}
+
 func TestProjectRatchetNotificationRejectsMissingText(t *testing.T) {
 	_, err := ProjectRatchetNotificationToMessagingSend(RatchetNotificationEvent{}, "ops")
 	if err == nil {


### PR DESCRIPTION
## Summary
- add parser helpers for ratchet blackboard notification-event JSON and JSONL exports
- add typed projection into workflow-plugin-messaging-core step.messaging_send input
- document that ratchet exports local events only while Workflow messaging plugins own delivery and credentials

## Verification
- go test ./...
- go build ./...
- git diff --check