### PR TITLE
ci: run plugin release on ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   release:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- move the tag release job from unavailable self-hosted runner labels to ubuntu-latest
- unblock v0.1.1 plugin artifact publication and workflow-registry dispatch

## Verification
- go test ./...
- git diff --check