### PR TITLE
ci: resolve draft release from release list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,16 @@ jobs:
           script: |
             const tag = context.ref.replace('refs/tags/', '');
             const { owner, repo } = context.repo;
-            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            let release;
+            for (let attempt = 0; attempt < 12; attempt++) {
+              const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+              release = releases.find(r => r.tag_name === tag);
+              if (release) break;
+              await new Promise(resolve => setTimeout(resolve, 5000));
+            }
+            if (!release) {
+              throw new Error(`draft release for tag ${tag} not found in repo listing (latest 100 releases)`);
+            }
             if (release.draft) {
               await github.rest.repos.updateRelease({
                 owner,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,13 +57,18 @@ jobs:
             const { owner, repo } = context.repo;
             let release;
             for (let attempt = 0; attempt < 12; attempt++) {
-              const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
-              release = releases.find(r => r.tag_name === tag);
-              if (release) break;
+              for (let page = 1; page <= 5; page++) {
+                const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100, page });
+                release = releases.find(r => r.tag_name === tag);
+                if (release || releases.length < 100) break;
+              }
+              if (release) {
+                break;
+              }
               await new Promise(resolve => setTimeout(resolve, 5000));
             }
             if (!release) {
-              throw new Error(`draft release for tag ${tag} not found in repo listing (latest 100 releases)`);
+              throw new Error(`draft release for tag ${tag} not found in latest 500 repository releases`);
             }
             if (release.draft) {
               await github.rest.repos.updateRelease({


### PR DESCRIPTION
## Summary
- resolve draft releases from the repository release list instead of getReleaseByTag
- match the guarded release lookup pattern used by ratchet-cli so draft plugin releases can be published reliably

## Verification
- go test ./...
- git diff --check